### PR TITLE
Update React to 16.8.0 and added new Typescript compiler options

### DIFF
--- a/packages/oc-template-typescript-react-compiler/lib/compileView.js
+++ b/packages/oc-template-typescript-react-compiler/lib/compileView.js
@@ -109,12 +109,18 @@ module.exports = (options, callback) => {
       next => fs.outputFile(
         path.join(tempPath, 'tsconfig.json'), JSON.stringify({
           files: [reactOCProviderName],
+          compilerOptions: {
+            lib: [
+              "es6",
+              "dom"
+            ]
+          },
           paths: {
             react: [path.join(__dirname, "../../node_modules/react")],
             "react-dom": [path.join(__dirname, "../../node_modules/react-dom")],
             "prop-types": [path.join(__dirname, "../../node_modules/prop-types")]
           }
-        }), 
+        }),
         next
       ),
       next => fs.outputFile(reactOCProviderPath, reactOCProviderContent, next),

--- a/packages/oc-template-typescript-react-compiler/package.json
+++ b/packages/oc-template-typescript-react-compiler/package.json
@@ -52,7 +52,7 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.9",
     "prop-types": "15.6.1",
-    "react": "16.4.0",
+    "react": "^16.8.0",
     "ts-loader": "^4.4.1",
     "typescript": "^2.9.2",
     "webpack": "^4.8.3"

--- a/packages/oc-template-typescript-react-compiler/scaffold/src/package.json
+++ b/packages/oc-template-typescript-react-compiler/scaffold/src/package.json
@@ -20,12 +20,11 @@
       }
     }
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
-    "@types/react": "^16.4.2",
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1",
+    "@types/react": "^16.8.0",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "oc-template-typescript-react-compiler": "*"
   }
 }


### PR DESCRIPTION
I'm open to discussion on best practices on bumping versions up. We can use this as a starting point however.