### PR TITLE
Fix issue with css modules not working

### DIFF
--- a/mocks/invalid-jsx-component/src/oc-app.d.ts
+++ b/mocks/invalid-jsx-component/src/oc-app.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="oc-template-typescript-react-compiler" />
+/// <reference types="oc-template-typescript-react" />
 
 /// <reference types="node" />
 /// <reference types="react" />

--- a/packages/oc-template-typescript-react-compiler/lib/oc-app.d.ts
+++ b/packages/oc-template-typescript-react-compiler/lib/oc-app.d.ts
@@ -1,22 +1,3 @@
-/// <reference types="node" />
-/// <reference types="react" />
-/// <reference types="react-dom" />
-
-declare module '*.css' {
-  const classes: { readonly [key: string]: string };
-  export default classes;
-}
-
-declare module '*.scss' {
-  const classes: { readonly [key: string]: string };
-  export default classes;
-}
-
-declare module '*.sass' {
-  const classes: { readonly [key: string]: string };
-  export default classes;
-}
-
 declare global {
   interface Window {
     oc: {

--- a/packages/oc-template-typescript-react-compiler/lib/verifyConfig.js
+++ b/packages/oc-template-typescript-react-compiler/lib/verifyConfig.js
@@ -227,7 +227,7 @@ function verifyTypeScriptSetup(componentPath) {
   if (!fs.existsSync(paths.appTypeDeclarations)) {
     fs.writeFileSync(
       paths.appTypeDeclarations,
-      `/// <reference types="oc-template-typescript-react-compiler" />${os.EOL}`
+      `/// <reference types="oc-template-typescript-react" />${os.EOL}`
     );
   }
 }

--- a/packages/oc-template-typescript-react-compiler/package.json
+++ b/packages/oc-template-typescript-react-compiler/package.json
@@ -59,7 +59,7 @@
     "oc-minify-file": "1.0.14",
     "oc-react-component-wrapper": "1.0.2",
     "oc-statics-compiler": "2.0.10",
-    "oc-template-typescript-react": "^2.0.0",
+    "oc-template-typescript-react": "^3.1.1",
     "oc-templates-messages": "1.0.2",
     "oc-view-wrapper": "1.0.3",
     "postcss-extend": "^1.0.5",

--- a/packages/oc-template-typescript-react-compiler/scaffold/src/src/oc-app.d.ts
+++ b/packages/oc-template-typescript-react-compiler/scaffold/src/src/oc-app.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="oc-template-typescript-react-compiler" />
+/// <reference types="oc-template-typescript-react" />

--- a/packages/oc-template-typescript-react/lib/oc-app.d.ts
+++ b/packages/oc-template-typescript-react/lib/oc-app.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="node" />
+/// <reference types="react" />
+/// <reference types="react-dom" />
+
+declare module '*.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.sass' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/packages/oc-template-typescript-react/package.json
+++ b/packages/oc-template-typescript-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-template-typescript-react",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "OC-Template-React",
   "main": "index.js",
   "repository": {
@@ -22,6 +22,7 @@
     "email": "piotr.bazydlo@gmail.com"
   },
   "license": "MIT",
+  "types": "./lib/oc-app.d.ts",
   "dependencies": {
     "minimal-request": "3.0.0",
     "nice-cache": "0.0.5",


### PR DESCRIPTION
Because oc-app.d.ts had declare modules and exports it didnt work as a
global export. So we moved the css declarations into
oc-template-typescript-react package and the Server exports in the
compiler package. That should solve the problem.