### PR TITLE
Add getSetting to the return type of useData hook

### DIFF
--- a/packages/oc-template-typescript-react-compiler/utils/useData.tsx
+++ b/packages/oc-template-typescript-react-compiler/utils/useData.tsx
@@ -8,7 +8,8 @@ type Data<T = any> = T & {
 }
 
 type PromiseData<T = any> = T & {
-  getData<O = any>(parameters?: Partial<T>): Promise<O>
+  getData<O = any>(parameters?: Partial<T>): Promise<O>;
+  getSetting(setting: 'name' | 'version' | 'baseUrl' | 'staticPath'): string
 }
 
 export const DataProvider = ({ children, ...props }: any) => {


### PR DESCRIPTION
Let's add `getSetting` to the return type of the `useData` hook. This will avoid typescript complaining:
![image](https://user-images.githubusercontent.com/18014700/209437883-8873e1e1-fbc9-4cef-bac9-2b32272e9f75.png)

```
type PromiseData<T = any> = T & {
  getData<O = any>(parameters?: Partial<T>): Promise<O>;
  getSetting(setting: 'name' | 'version' | 'baseUrl' | 'staticPath'): string
}
```