### PR TITLE
Remove react-component bundle and insert it into template.js

### DIFF
--- a/packages/oc-template-typescript-react-compiler/lib/compileView.js
+++ b/packages/oc-template-typescript-react-compiler/lib/compileView.js
@@ -11,7 +11,7 @@ const strings = require('oc-templates-messages');
 const reactBundleWrapper = (content) => {
   const iife = `(function() {
   ${content}
-  ; return module.default}());`
+  ; return module.default}());`;
 
   return iife;
 };

--- a/packages/oc-template-typescript-react-compiler/lib/compileView.js
+++ b/packages/oc-template-typescript-react-compiler/lib/compileView.js
@@ -8,11 +8,12 @@ const ocViewWrapper = require('oc-view-wrapper');
 const path = require('path');
 const strings = require('oc-templates-messages');
 
-const reactComponentWrapper = (hash, content, nameSpace) => {
-  nameSpace = nameSpace || 'oc';
-  return `var ${nameSpace}=${nameSpace}||{};${nameSpace}.reactComponents=${nameSpace}.reactComponents||{};${nameSpace}.reactComponents['${hash}']=${nameSpace}.reactComponents['${hash}']||(function(){
-    ${content}
-	; return module.default}())`;
+const reactBundleWrapper = (content) => {
+  const iife = `(function() {
+  ${content}
+  ; return module.default}());`
+
+  return iife;
 };
 
 const {
@@ -76,10 +77,7 @@ module.exports = (options, callback) => {
       const bundle = memoryFs.readFileSync(`/build/${config.output.filename}`, 'UTF8');
 
       const bundleHash = hashBuilder.fromString(bundle);
-      const bundleName = 'react-component';
-      const bundlePath = path.join(publishPath, `${bundleName}.js`);
-      const wrappedBundle = reactComponentWrapper(bundleHash, bundle);
-      fs.outputFileSync(bundlePath, wrappedBundle);
+      const wrappedBundle = reactBundleWrapper(bundle);
 
       let css = null;
       const cssFile = Object.keys(data.build).filter((x) => x.endsWith('.css'))[0];
@@ -99,8 +97,8 @@ module.exports = (options, callback) => {
         reactRoot,
         css,
         externals,
-        bundleHash,
-        bundleName
+        wrappedBundle,
+        hash: bundleHash
       });
 
       const templateStringCompressed = production

--- a/packages/oc-template-typescript-react-compiler/lib/viewTemplate.js
+++ b/packages/oc-template-typescript-react-compiler/lib/viewTemplate.js
@@ -5,7 +5,7 @@ const viewTemplate = ({ reactRoot, css, externals, wrappedBundle, hash }) => `fu
   window.oc = window.oc || {};
   window.oc.__typescriptReactTemplate = window.oc.__typescriptReactTemplate || { count: 0 };
   oc.reactComponents = oc.reactComponents || {};
-  oc.reactComponents['${hash}'] = ${wrappedBundle};
+  oc.reactComponents['${hash}'] = oc.reactComponents['${hash}'] || (${wrappedBundle});
   var count = window.oc.__typescriptReactTemplate.count;
   var templateId = "${reactRoot}-" + count;
   window.oc.__typescriptReactTemplate.count++;

--- a/packages/oc-template-typescript-react-compiler/lib/viewTemplate.js
+++ b/packages/oc-template-typescript-react-compiler/lib/viewTemplate.js
@@ -1,9 +1,11 @@
-const viewTemplate = ({ reactRoot, css, externals, bundleHash, bundleName }) => `function(model){
+const viewTemplate = ({ reactRoot, css, externals, wrappedBundle, hash }) => `function(model){
   var modelHTML =  model.__html ? model.__html : '';
   var staticPath = model.reactComponent.props._staticPath;
   var props = JSON.stringify(model.reactComponent.props);
   window.oc = window.oc || {};
   window.oc.__typescriptReactTemplate = window.oc.__typescriptReactTemplate || { count: 0 };
+  oc.reactComponents = oc.reactComponents || {};
+  oc.reactComponents['${hash}'] = ${wrappedBundle};
   var count = window.oc.__typescriptReactTemplate.count;
   var templateId = "${reactRoot}-" + count;
   window.oc.__typescriptReactTemplate.count++;
@@ -15,21 +17,15 @@ const viewTemplate = ({ reactRoot, css, externals, bundleHash, bundleName }) => 
     'oc.cmd.push(function(oc){' +
     '${css ? "oc.events.fire(\\'oc:cssDidMount\\', \\'" + css + "\\');" : ''}' +
       'oc.requireSeries(${JSON.stringify(externals)}, function(){' +
-        'oc.require(' +
-          '["oc", "reactComponents", "${bundleHash}"],' + 
-          '"' + staticPath + '${bundleName}.js",' +
-          'function(ReactComponent){' +
-            'var targetNode = document.getElementById("' + templateId + '");' +
-            'targetNode.setAttribute("id","");' +
-            'var reactElement = React.createElement(ReactComponent,' +  props + ');' +
-            'if (ReactDOM.createRoot) {' +
-              'var root = ReactDOM.createRoot(targetNode);' +
-              'root.render(reactElement);' +
-            '} else {' +
-              'ReactDOM.render(reactElement, targetNode);' +
-            '}' +
-          '}' +
-        ');' +
+        'var targetNode = document.getElementById("' + templateId + '");' +
+        'targetNode.setAttribute("id","");' +
+        'var reactElement = React.createElement(oc.reactComponents["${hash}"],' +  props + ');' +
+        'if (ReactDOM.createRoot) {' +
+          'var root = ReactDOM.createRoot(targetNode);' +
+          'root.render(reactElement);' +
+        '} else {' +
+          'ReactDOM.render(reactElement, targetNode);' +
+        '}' +
       '});' +
     '});' +
   '</script>'


### PR DESCRIPTION
This inserts the react-component bundle into the `template.js`, so we reduce it from 2 requests (template.js and then react-component.js) to only one.