### PR TITLE
Escape CSS before appending into style tag / Fixes Tailwind support

### DIFF
--- a/packages/oc-template-typescript-react-compiler/lib/htmlTemplate.js
+++ b/packages/oc-template-typescript-react-compiler/lib/htmlTemplate.js
@@ -1,3 +1,5 @@
+const escapeCSS = require('cssesc');
+
 const viewTemplate = ({ templateId, css, externals, bundle, hash }) => `function(model){
   oc.reactComponents = oc.reactComponents || {};
   oc.reactComponents['${hash}'] = oc.reactComponents['${hash}'] || (${bundle});
@@ -11,7 +13,7 @@ const viewTemplate = ({ templateId, css, externals, bundle, hash }) => `function
   var templateId = "${templateId}-" + count;
   oc.__typescriptReactTemplate.count++;
   return '<div id="' + templateId + '" class="${templateId}">' + modelHTML + '</div>' +
-    '${css ? '<style>' + css + '</style>' : ''}' +
+    '${css ? '<style>' + escapeCSS(css) + '</style>' : ''}' +
     '<script>' +
     'oc = oc || {};' +
     'oc.cmd = oc.cmd || [];' +

--- a/packages/oc-template-typescript-react-compiler/package.json
+++ b/packages/oc-template-typescript-react-compiler/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@vitejs/plugin-react": "^3.1.0",
     "chalk": "^3.0.0",
+    "cssesc": "^3.0.0",
     "immer": "^9.0.6",
     "oc-generic-template-compiler": "2.1.0",
     "oc-statics-compiler": "2.0.10",


### PR DESCRIPTION
When CSS selectors with colons (among other chars) are used, as popularised by Tailwind e.g. `md:flex`, they must be escaped before appended to the style tag, otherwise they won't work. This means this template as is do not fully support Tailwind.

To solve this I've added added a tiny lib called [cssesc](https://www.npmjs.com/package/cssesc) which is very similar to [Web API's CSS.escape](https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape_static).


Before:
![image](https://github.com/guestlinelabs/oc-template-typescript-react/assets/5303585/bbf7cb38-3ca9-4542-855c-3f3dcc2ef4e2)


After:
![image](https://github.com/guestlinelabs/oc-template-typescript-react/assets/5303585/a508627d-e053-4c26-be34-94736c78380d)

